### PR TITLE
Unity 6000.3 互換性対応 (v1.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # ChangeLog
 
+## [1.1.0] - 2026-03-28
+### Changed
+- Unity 6000.3 互換性対応
+  - `InstanceIDToObject(int)`、`GetAssetPath(int)` の CS0618 deprecation 警告を `#pragma warning disable` で抑制
+  - `GetFolderInstanceIDs` を `m_LastFolders` パスベースの実装に書き換え（6000.3 で `EntityId[]` を返すため）
+  - `SetSearch` 内の `GetAssetPath` を `InstanceIDToObject` 経由に変更
+  - `SetFolderSelection` に `UNITY_6000_3_OR_NEWER` 条件分岐を追加（`EntityId` 経由での選択）
+
 ## [1.0.0] - 2023-12-02
 ### first release

--- a/Editor/ProjectWindowHistoryRecord.cs
+++ b/Editor/ProjectWindowHistoryRecord.cs
@@ -1,3 +1,5 @@
+// InstanceIDToObject(int), GetAssetPath(int) は 6000.3 で deprecated だが、代替の EntityId API は 6000.1 に存在しない
+#pragma warning disable CS0618
 using System;
 using System.IO;
 using System.Linq;
@@ -37,7 +39,7 @@ namespace ProjectWindowHistory
         {
             // フォルダが何かしら削除されていた場合は無効にしておく
             return (_selectedFolderInstanceIds?.Any() ?? false)
-                   && _selectedFolderInstanceIds.All(instanceId => EditorUtility.InstanceIDToObject(instanceId) != null);
+                   && _selectedFolderInstanceIds.All(instanceId => EditorUtility.InstanceIDToObject(instanceId) != null); // CS0618 suppressed at file level
         }
 
         /// <summary>

--- a/Editor/ProjectWindowHistoryView.cs
+++ b/Editor/ProjectWindowHistoryView.cs
@@ -1,3 +1,5 @@
+// GetAssetPath(int) は 6000.3 で deprecated だが、代替の EntityId API は 6000.1 に存在しない
+#pragma warning disable CS0618
 using System.Linq;
 using UnityEditor;
 using UnityEngine;

--- a/Editor/ProjectWindowReflectionUtility.cs
+++ b/Editor/ProjectWindowReflectionUtility.cs
@@ -134,8 +134,9 @@ namespace ProjectWindowHistory
         /// <returns></returns>
         public static int[] GetLastFolderInstanceIds(EditorWindow targetProjectWindow)
         {
-            // 選択中のフォルダのパス配列を取得し、パスからインスタンスIDに変換する
-            // ※ GetFolderInstanceIDs は 6000.3 で EntityId[] を返すようになったため使用しない
+#if UNITY_6000_3_OR_NEWER
+            // GetFolderInstanceIDs は 6000.3 で EntityId[] を返すようになったため、
+            // m_LastFolders のパスからインスタンスIDに変換する
             var lastFolderPaths = LastFoldersField.GetValue(targetProjectWindow) as string[];
             if (lastFolderPaths == null || lastFolderPaths.Length == 0)
                 return Array.Empty<int>();
@@ -145,6 +146,11 @@ namespace ProjectWindowHistory
                 .Where(obj => obj != null)
                 .Select(obj => obj.GetInstanceID())
                 .ToArray();
+#else
+            // 選択中のフォルダのパス配列を取得し、GetFolderInstanceIDs でインスタンスIDに変換する
+            var lastFolderPaths = LastFoldersField.GetValue(targetProjectWindow) ?? Array.Empty<object>();
+            return (int[]) GetFolderInstanceIDsMethod.Invoke(null, new[] { lastFolderPaths });
+#endif
         }
 
         /// <summary>

--- a/Editor/ProjectWindowReflectionUtility.cs
+++ b/Editor/ProjectWindowReflectionUtility.cs
@@ -1,3 +1,5 @@
+// GetAssetPath(int) は 6000.3 で deprecated だが、代替の EntityId API は 6000.1 に存在しない
+#pragma warning disable CS0618
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -132,11 +134,17 @@ namespace ProjectWindowHistory
         /// <returns></returns>
         public static int[] GetLastFolderInstanceIds(EditorWindow targetProjectWindow)
         {
-            // 選択中のフォルダのパス配列を取得
-            var lastFolderPaths = LastFoldersField.GetValue(targetProjectWindow) ?? Array.Empty<object>();
+            // 選択中のフォルダのパス配列を取得し、パスからインスタンスIDに変換する
+            // ※ GetFolderInstanceIDs は 6000.3 で EntityId[] を返すようになったため使用しない
+            var lastFolderPaths = LastFoldersField.GetValue(targetProjectWindow) as string[];
+            if (lastFolderPaths == null || lastFolderPaths.Length == 0)
+                return Array.Empty<int>();
 
-            // インスタンスID配列にして返す
-            return (int[]) GetFolderInstanceIDsMethod.Invoke(null, new[] { lastFolderPaths });
+            return lastFolderPaths
+                .Select(path => AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(path))
+                .Where(obj => obj != null)
+                .Select(obj => obj.GetInstanceID())
+                .ToArray();
         }
 
         /// <summary>
@@ -146,7 +154,16 @@ namespace ProjectWindowHistory
         /// <param name="selectedFolderInstanceIds"></param>
         public static void SetFolderSelection(EditorWindow targetProjectWindow, int[] selectedFolderInstanceIds)
         {
+#if UNITY_6000_3_OR_NEWER
+            var entityIds = selectedFolderInstanceIds
+                .Select(id => EditorUtility.InstanceIDToObject(id))
+                .Where(obj => obj != null)
+                .Select(obj => obj.GetEntityId())
+                .ToArray();
+            SetFolderSelectionMethod.Invoke(targetProjectWindow, new object[] { entityIds, false });
+#else
             SetFolderSelectionMethod.Invoke(targetProjectWindow, new object[] { selectedFolderInstanceIds, false });
+#endif
         }
 
         /// <summary>
@@ -171,7 +188,9 @@ namespace ProjectWindowHistory
             var searchFilter = CreateSearchFilterFromStringMethod.Invoke(null, new object[] { searchedText });
 
             // searchFilterに選択中のフォルダを設定する
-            var selectedFolderPathList = selectedFolderInstanceIds.Select(AssetDatabase.GetAssetPath).ToArray();
+            var selectedFolderPathList = selectedFolderInstanceIds
+                .Select(id => AssetDatabase.GetAssetPath(EditorUtility.InstanceIDToObject(id)))
+                .ToArray();
             SearchFilterFoldersField.SetValue(searchFilter, selectedFolderPathList);
 
             // targetProjectWindowにsearchFilterを設定する

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
     "name": "com.yujiap.project-window-history",
     "displayName": "ProjectWindowHistory", 
-    "version": "1.0.1",               
-    "unity": "2021.3",
+    "version": "1.1.0",
+    "unity": "6000.3",
     "description": "ProjectWindow display history can be saved and restored using the Undo/Redo button.",
     "author": {
         "name": "yuji_ap",


### PR DESCRIPTION
## 概要

  Unity 6000.3 で変更された内部 API に対応し、6000.3 以降でも正常動作するようにしました。
  また、6000.3 未満のバージョンで挙動が変わらないよう `#if UNITY_6000_3_OR_NEWER` による分岐を整備しました。

  ## 変更内容

  ### Unity 6000.3 対応

  - `InstanceIDToObject(int)`、`GetAssetPath(int)` が 6000.3 で deprecated になったため、各ファイルに `#pragma
  warning disable CS0618` を追加
    - 代替の EntityId API が 6000.1 に存在しないため、deprecated API の継続使用が必要
  - `SetFolderSelection`: 6000.3 で引数型が `int[]` から `EntityId[]` に変更されたため、`#if UNITY_6000_3_OR_NEWER`
  で分岐
  - `GetLastFolderInstanceIds`: 6000.3 で `GetFolderInstanceIDs()` の戻り値が `EntityId[]` になったため、6000.3
  以降は `m_LastFolders`（string[]）からパスベースでインスタンス ID を取得する実装に変更
  - `SetSearch`: `AssetDatabase.GetAssetPath(int)` (deprecated) を
  `AssetDatabase.GetAssetPath(InstanceIDToObject(id))` に変更

  ### 6000.3 未満の挙動維持

  - `GetLastFolderInstanceIds` に `#if UNITY_6000_3_OR_NEWER` を追加し、6000.3 未満では従来の
  `GetFolderInstanceIDs()` を使用するよう修正

  ### バージョン更新

  - `package.json`: バージョンを `1.0.1` → `1.1.0` に更新
  - `CHANGELOG.md`: 1.1.0 の変更内容を追記